### PR TITLE
Test clean col install year

### DIFF
--- a/data_cleaning/clean_wpdx_sample_data.py
+++ b/data_cleaning/clean_wpdx_sample_data.py
@@ -28,8 +28,23 @@ def clean_col_install_year(input_data):
     """
     Clean values in column: "install_year"
     Trello card: https://trello.com/c/KjLEFR24/8-column-installyear
+    
+    We need to produce a 4 digit integer. If year is string, casting it as
+    integer still works.
     """
-    return input_data
+    if type(input_data) == str:
+        input_data_length=min(4,len(input_data))
+        if str.isdigit(input_data[:input_data_length]) == True:
+            integer_input_data = int(input_data[:input_data_length])
+            output = integer_input_data
+        else:
+            output = 'None'
+    
+    else:
+        integer_input_data = int(input_data)
+        output = integer_input_data
+    
+    return output
 
 
 if __name__ == '__main__':

--- a/data_cleaning/clean_wpdx_sample_data.py
+++ b/data_cleaning/clean_wpdx_sample_data.py
@@ -24,6 +24,13 @@ def clean_col_country_name(input_data):
     """
     return input_data
 
+def clean_col_install_year(input_data):
+    """
+    Clean values in column: "install_year"
+    Trello card: https://trello.com/c/KjLEFR24/8-column-installyear
+    """
+    return input_data
+
 
 if __name__ == '__main__':
     clean_columns('wpdx_sample_data.csv', 'cleaned_wpdx_sample_data.csv')

--- a/data_cleaning/test_clean_wpdx_sample_data.py
+++ b/data_cleaning/test_clean_wpdx_sample_data.py
@@ -7,3 +7,9 @@ def test_clean_col_country_name():
     Test the cleaning for column: "country_name"
     """
     assert clean_wpdx_sample_data.clean_col_country_name('NA') == 'NA'
+
+def test_clean_col_install_year():
+    """
+    Test the cleaning for column: "install_year"
+    """
+    assert clean_wpdx_sample_data.clean_col_install_year('2001.') == 2001


### PR DESCRIPTION
Hello. 
As described in Trello board, I've added an install year column analysis. It inspects for strings, and extracts the 4 integers that compose the year. 
Will produce a 'None' if the input_data is not a 4 year digit or if it cannot be reduced to that. 

Hope I am not screwing up something. Sorry if that's the case. 