### PR TITLE
Clean `country_name`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,5 +109,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# vim
+**/*.swo
+**/*.swp
+
 # VS Code
 .vscode/

--- a/data_cleaning/clean_wpdx_sample_data.py
+++ b/data_cleaning/clean_wpdx_sample_data.py
@@ -23,7 +23,7 @@ def clean_columns(input_file, output_file):
 
                 if col_name in dirty_col_list:
                     col_value = globals()['clean_col_' + col_name](col_value)
-  
+
                 if "," in str(col_value):
                     col_value = '"' + str(col_value) + '"'
 
@@ -37,7 +37,17 @@ def clean_col_country_name(input_data):
     Clean values in column: "country_name"
     Trello card: https://trello.com/c/HHzNs0hS/1-column-countryname
     """
+    replacements = {
+        'Swaziland': 'Eswatini', # country got renamed
+        'Bolivia, Plurinational State of': 'Bolivia (Plurinational State of)',
+        'Congo, The Democratic Republic of the': 'Congo (Democratic Republic of the)'
+    }
+
+    if input_data in replacements.keys():
+        return replacements[input_data]
+
     return input_data
+
 
 def clean_col_country_id(input_data):
     if input_data.isalpha():

--- a/data_cleaning/test_clean_wpdx_sample_data.py
+++ b/data_cleaning/test_clean_wpdx_sample_data.py
@@ -8,7 +8,9 @@ def test_clean_col_country_name():
     """
     Test the cleaning for column: "country_name"
     """
-    assert cwsd.clean_col_country_name('NA') == 'NA'
+    assert cwsd.clean_col_country_name('Swaziland') == 'Eswatini'
+    assert cwsd.clean_col_country_name('Bolivia, Plurinational State of') == 'Bolivia (Plurinational State of)'
+    assert cwsd.clean_col_country_name('Congo, The Democratic Republic of the') == 'Congo (Democratic Republic of the)'
 
 
 def test_clean_col_country_id():


### PR DESCRIPTION
https://trello.com/c/HHzNs0hS/1-column-countryname

There were only 3 unique names which did not match the ISO format. This fixes those.

Note that the `country_name` column is likely redundant since `country_id` exists.
